### PR TITLE
Clip lorenz

### DIFF
--- a/HyperParameterOpt/GenerateExperiments/experiment_template.py
+++ b/HyperParameterOpt/GenerateExperiments/experiment_template.py
@@ -8,10 +8,11 @@ from scipy import integrate
 DIFF_EQ_PARAMS = {
                   "x0": [-20, 10, -.5],
                   "begin": 0,
-                  "end": 60,
-                  "timesteps":60000,
+                  "end": 100,
+                  "timesteps":100000,
                   "train_per": .66,
                   "solver": lorenz_equ
+                  "clip": 40
                  }
 
 RES_PARAMS = {

--- a/HyperParameterOpt/GenerateExperiments/experiment_template.py
+++ b/HyperParameterOpt/GenerateExperiments/experiment_template.py
@@ -8,10 +8,10 @@ from scipy import integrate
 DIFF_EQ_PARAMS = {
                   "x0": [-20, 10, -.5],
                   "begin": 0,
-                  "end": 100,
-                  "timesteps":100000,
-                  "train_per": .66,
-                  "solver": lorenz_equ
+                  "end": 85,
+                  "timesteps": 85000,
+                  "train_per": .889,
+                  "solver": lorenz_equ,
                   "clip": 40
                  }
 


### PR DESCRIPTION
I added a parameter to the experiment that clips off the first 40 seconds. I also set the default test signal length to 5 seconds. Shortening the test sequence should speed up the reservoir prediction step.